### PR TITLE
Log successes and failures for users.

### DIFF
--- a/.github/workflows/speech-test-data-ci.yml
+++ b/.github/workflows/speech-test-data-ci.yml
@@ -107,7 +107,11 @@ jobs:
           zip -r ${{ env.TEST_BUILD_FOLDER_PATH }}/${{ env.TEST_AUDIO_ZIP_FILE }} ${{ env.TEST_BUILD_FOLDER_PATH }} -x "*.txt"
           speech dataset create -n audio_trans_test_${{ env.CURRENT_COMMIT_HASH }} -a ${{ env.TEST_BUILD_FOLDER_PATH }}/${{ env.TEST_AUDIO_ZIP_FILE }} -t ${{ env.TEST_BUILD_FOLDER_PATH }}/${{ env.TEST_TRANS_FILE }} --wait > ${{ env.TEST_BUILD_FOLDER_PATH }}/audio-trans-test-upload.txt
           audio_trans_test_id=$(cat ${{ env.TEST_BUILD_FOLDER_PATH }}/audio-trans-test-upload.txt | sed -n '3p')
-          if ! [[ ${audio_trans_test_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${audio_trans_test_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to upload audio and human-labeled transcript testing data. Check that the correct paths are defined in environment variables or re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=AUDIO_TRANS_TEST_ID::$(echo $audio_trans_test_id)"
 
       # Get the benchmark Speech model. Fail if a GUID is not generated.
@@ -115,7 +119,11 @@ jobs:
         run: |
           speech model list > ${{ env.TEST_BUILD_FOLDER_PATH }}/speech-model-list.txt
           custom_speech_model_id=$(cat ${{ env.TEST_BUILD_FOLDER_PATH }}/speech-model-list.txt | tail -1 | awk '{print $1;}')
-          if ! [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to get the benchmark Custom Speech model. Possibly re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=CUSTOM_SPEECH_MODEL_ID::$(echo $custom_speech_model_id)"
 
       # Test with Speech. Fail if a GUID is not generated.
@@ -123,7 +131,11 @@ jobs:
         run: |
           speech test create -n test_from_test_data_update_${{ env.CURRENT_COMMIT_HASH }} -a ${{ env.AUDIO_TRANS_TEST_ID }} -m ${{ env.CUSTOM_SPEECH_MODEL_ID }} -lm ${{ env.CUSTOM_SPEECH_MODEL_ID }} --wait > ${{ env.TEST_BUILD_FOLDER_PATH }}/test-output.txt
           test_id=$(cat ${{ env.TEST_BUILD_FOLDER_PATH }}/test-output.txt | sed -n '3p')
-          if ! [[ ${test_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${test_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to test the Custom Speech model. Possibly re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=TEST_ID::$(echo $test_id)"
 
       # Get the content from the test and remove the first line, which is

--- a/.github/workflows/speech-train-data-ci-cd.yml
+++ b/.github/workflows/speech-train-data-ci-cd.yml
@@ -58,8 +58,8 @@ jobs:
           results_container_exists=$(node --eval "fs.readFile('verify-test-results-container.json','utf8',(err,data)=>console.log(JSON.parse(data).exists))")
           if [ $results_container_exists != 'true' ]
           then
-            echo CREATING TEST RESULTS CONTAINER...
             az storage container create --account-name ${{ secrets.STORAGE_ACCOUNT_NAME }} --name test-results --auth-mode login
+            echo CREATED TEST RESULTS CONTAINER.
           fi
 
       - name: Create the configuration container if needed
@@ -68,8 +68,8 @@ jobs:
           config_container_exists=$(node --eval "fs.readFile('verify-configuration-container.json','utf8',(err,data)=>console.log(JSON.parse(data).exists))")
           if [ $config_container_exists != 'true' ]
           then
-            echo CREATING CONFIGURATION CONTAINER...
             az storage container create --account-name ${{ secrets.STORAGE_ACCOUNT_NAME }} --name configuration --public-access blob --auth-mode login
+            echo CREATED CONFIGURATION CONTAINER.
           fi
 
   #############################################################################
@@ -101,7 +101,7 @@ jobs:
           echo "::set-env name=CUSTOM_SPEECH_MODEL_DATA::"
           echo "::set-env name=TEST_AUDIO_ZIP_FILE::test-audio.zip"
           echo "::set-env name=TEST_BUILD_FOLDER_PATH::build-speech-test"
-          echo "::set-env name=TRAIN_AUDIO_ZIP_FILE::'train-audio.zip'"
+          echo "::set-env name=TRAIN_AUDIO_ZIP_FILE::train-audio.zip"
           echo "::set-env name=TRAIN_BUILD_FOLDER_PATH::build-speech-train"
 
       # https://github.com/msimecek/Azure-Speech-CLI
@@ -123,7 +123,11 @@ jobs:
           zip -r ${{ env.TRAIN_BUILD_FOLDER_PATH }}/${{ env.TRAIN_AUDIO_ZIP_FILE }} ${{ env.TRAIN_BUILD_FOLDER_PATH }} -x "*.txt"
           speech dataset create -n audio_trans_train_${{ env.CURRENT_COMMIT_HASH }} -a ${{ env.TRAIN_BUILD_FOLDER_PATH }}/${{ env.TRAIN_AUDIO_ZIP_FILE }} -t ${{ env.TRAIN_BUILD_FOLDER_PATH }}/${{ env.TRAIN_TRANS_FILE }} --wait > ${{ env.TRAIN_BUILD_FOLDER_PATH }}/audio-trans-train-upload.txt
           audio_trans_train_id=$(cat ${{ env.TRAIN_BUILD_FOLDER_PATH }}/audio-trans-train-upload.txt | sed -n '3p')
-          if ! [[ ${audio_trans_train_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${audio_trans_train_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to upload audio and human-labeled transcript training data. Check that the correct paths are defined in environment variables or re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=AUDIO_TRANS_TRAIN_ID::$(echo $audio_trans_train_id)"
           echo "::set-env name=CUSTOM_SPEECH_MODEL_DATA::--audio-dataset $audio_trans_train_id"
 
@@ -133,7 +137,11 @@ jobs:
         run: |
           speech dataset create -n pronunciation_${{ env.CURRENT_COMMIT_HASH }} -pro ${{ env.PRONUNCIATION_FILE_PATH }} --wait > ${{ env.TRAIN_BUILD_FOLDER_PATH }}/pronunciation-upload.txt
           pronunciation_id=$(cat ${{ env.TRAIN_BUILD_FOLDER_PATH }}/pronunciation-upload.txt | sed -n '3p' )
-          if ! [[ ${pronunciation_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${pronunciation_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to upload pronunciation data. Check that the correct paths are defined in environment variables or re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=PRONUNCIATION_ID::$(echo $pronunciation_id)"
           echo "::set-env name=CUSTOM_SPEECH_MODEL_DATA::${{ env.CUSTOM_SPEECH_MODEL_DATA }} -pro $pronunciation_id"
 
@@ -143,7 +151,11 @@ jobs:
         run: |
           speech dataset create -n language_${{ env.CURRENT_COMMIT_HASH }} -lng ${{ env.RELATED_TEXT_FILE_PATH }} --wait > ${{ env.TRAIN_BUILD_FOLDER_PATH }}/language-upload.txt
           language_id=$(cat ${{ env.TRAIN_BUILD_FOLDER_PATH }}/language-upload.txt | sed -n '3p')
-          if ! [[ ${language_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${language_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to upload language data. Check that the correct paths are defined in environment variables or re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=LANGUAGE_ID::$(echo $language_id)"
           echo "::set-env name=CUSTOM_SPEECH_MODEL_DATA::${{ env.CUSTOM_SPEECH_MODEL_DATA }} -lng $language_id"
 
@@ -151,7 +163,11 @@ jobs:
         run: |
           speech model list-scenarios --locale ${{ env.SPEECH_LOCALE }} --simple > ${{ env.TRAIN_BUILD_FOLDER_PATH }}/base-models.txt
           base_model_id=$(head -n 1 ${{ env.TRAIN_BUILD_FOLDER_PATH }}/base-models.txt)
-          if ! [[ ${base_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${base_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to get the latest baseline model. Possibly re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=BASE_MODEL_ID::$(echo $base_model_id)"
 
       # Assemble and upload the Custom Speech Model using only the training data
@@ -160,30 +176,35 @@ jobs:
         run: |
           speech model create -l ${{ env.SPEECH_LOCALE }} ${{ env.CUSTOM_SPEECH_MODEL_DATA }} -s ${{ env.BASE_MODEL_ID }} -n custom_speech_model_${{ env.CURRENT_COMMIT_HASH }} --wait > ${{ env.TRAIN_BUILD_FOLDER_PATH }}/model-creation-output.txt
           custom_speech_model_id=$(cat ${{ env.TRAIN_BUILD_FOLDER_PATH }}/model-creation-output.txt | sed -n '3p')
-          if ! [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to create a Custom Speech model. Possibly re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=CUSTOM_SPEECH_MODEL_ID::$(echo $custom_speech_model_id)"
 
-      # Nuance: setting a local variable for env retrieved values.
-      # Working solution to text expansion within the "if [[]]; then fi", which results in a substitution error.
+      # Nuance: setting a local variable for env retrieved values. Working
+      # solution to text expansion within the "if [[]]; then fi", which results
+      # in a substitution error.
       - name: Delete Custom Speech training dataset after model is created
         run: |
           audio_trans_train_id=${{ env.AUDIO_TRANS_TRAIN_ID }}
-          if [[ ${audio_trans_train_id//-/} =~ ^[[:xdigit:]]{32}$ ]];
+          if [[ ${audio_trans_train_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
           then
-            speech dataset delete ${{ env.AUDIO_TRANS_TRAIN_ID }};
-            echo "AUDIO TRANS TRAIN DATASET DELETED"
+            speech dataset delete ${{ env.AUDIO_TRANS_TRAIN_ID }}
+            echo DELETED AUDIO+HUMAN-LABELED TRANSCRIPT TRAINING DATA.
           fi
           pronunciation_id=${{ env.PRONUNCIATION_ID }}
-          if [[ ${pronunciation_id//-/} =~ ^[[:xdigit:]]{32}$ ]];
+          if [[ ${pronunciation_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
           then
-            speech dataset delete ${{ env.PRONUNCIATION_ID }};
-            echo "PRONUNCIATION TRAIN DATASET DELETED"
+            speech dataset delete ${{ env.PRONUNCIATION_ID }}
+            echo DELETED PRONUNCIATION DATA.
           fi
           language_id=${{ env.LANGUAGE_ID }}
-          if [[ ${language_id//-/} =~ ^[[:xdigit:]]{32}$ ]];
+          if [[ ${language_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
           then
-            speech dataset delete ${{ env.LANGUAGE_ID }};
-            echo "LANGUAGE TRAIN DATASET DELETED"
+            speech dataset delete ${{ env.LANGUAGE_ID }}
+            echo DELETED LANGUAGE DATA.
           fi
 
       #########################################################################
@@ -209,7 +230,11 @@ jobs:
             speech dataset create -n audio_trans_test_${{ env.CURRENT_COMMIT_HASH }} -a ${{ env.TEST_BUILD_FOLDER_PATH }}/${{ env.TEST_AUDIO_ZIP_FILE }} -t ${{ env.TEST_BUILD_FOLDER_PATH }}/${{ env.TEST_TRANS_FILE }} --wait > ${{ env.TEST_BUILD_FOLDER_PATH }}/audio-trans-test-upload.txt
             audio_trans_test_id=$(cat ${{ env.TEST_BUILD_FOLDER_PATH }}/audio-trans-test-upload.txt | sed -n '3p')
           fi
-          if ! [[ ${audio_trans_test_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${audio_trans_test_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to upload audio and human-labeled transcript testing data. Check that the correct paths are defined in environment variables or re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=AUDIO_TRANS_TEST_ID::$(echo $audio_trans_test_id)"
 
       # Test with Speech. Fail if a GUID is not generated.
@@ -218,7 +243,11 @@ jobs:
           speech test create -n test_from_train_data_update_${{ env.CURRENT_COMMIT_HASH }} -a ${{ env.AUDIO_TRANS_TEST_ID }} -m ${{ env.CUSTOM_SPEECH_MODEL_ID }} -lm ${{ env.CUSTOM_SPEECH_MODEL_ID }} --wait > ${{ env.TEST_BUILD_FOLDER_PATH }}/test-output.txt
           test_id=$(cat ${{ env.TEST_BUILD_FOLDER_PATH }}/test-output.txt | sed -n '3p')
           echo "::set-env name=TEST_ID::$(echo $test_id)"
-          if ! [[ ${test_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${test_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to test the Custom Speech model. Possibly re-run all jobs."
+            exit 1
+          fi
 
       # Get the content from the test and remove the first line, which is
       # logging, so the result is a JSON file.
@@ -284,16 +313,17 @@ jobs:
           echo ${{ env.TEST_SUMMARY_FILE }} > ${{ env.TEST_BUILD_FOLDER_PATH }}/benchmark-test.txt
           az storage blob upload --account-name ${{ secrets.STORAGE_ACCOUNT_NAME }} --container-name configuration --name benchmark-test.txt --file ${{ env.TEST_BUILD_FOLDER_PATH }}/benchmark-test.txt --auth-mode login
 
-      # Nuance: setting a local variable for env retrieved values.
-      # Working solution to text expansion within the "if [[]]; then fi", which results in a substitution error.
+      # Nuance: setting a local variable for env retrieved values. Working
+      # solution to text expansion within the "if [[]]; then fi", which results
+      # in a substitution error.
       - name: FAIL - Delete training uploads to Speech
         if: env.BENCHMARK_WER <= env.NEW_WER
         run: |
           custom_speech_model_id=${{ env.CUSTOM_SPEECH_MODEL_ID }}
-          if [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]];
+          if [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
           then
-            speech model delete ${{ env.CUSTOM_SPEECH_MODEL_ID }};
-            echo "FAILED TO IMPROVE DELETING MODEL"
+            speech model delete ${{ env.CUSTOM_SPEECH_MODEL_ID }}
+            echo DELETED CUSTOM SPEECH MODEL.
           fi
           exit 1
 
@@ -353,7 +383,11 @@ jobs:
           mkdir ${{ env.TRAIN_BUILD_FOLDER_PATH }}
           speech model list > ${{ env.TRAIN_BUILD_FOLDER_PATH }}/speech-model-list.txt
           custom_speech_model_id=$(cat ${{ env.TRAIN_BUILD_FOLDER_PATH }}/speech-model-list.txt | tail -1 | awk '{print $1;}')
-          if ! [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to get the benchmark Custom Speech model. Possibly re-run all jobs."
+            exit 1
+          fi
           echo "::set-env name=CUSTOM_SPEECH_MODEL_ID::$(echo $custom_speech_model_id)"
 
       - name: Delete all but the 5 latest models
@@ -363,12 +397,14 @@ jobs:
           sed -i '1d' $file
           sed -i '$d' $file
           number_of_models_to_delete=`expr $(cat $file | wc -l) - 5`
-          if [[ $number_of_models_to_delete -gt 0 ]]; then
+          if [[ $number_of_models_to_delete -gt 0 ]]
+          then
             while read -a line
             do
               if [[ ${line//-/} =~ ^[[:xdigit:]]{32}$ ]];
               then
                 speech model delete "$line"
+                echo DELETED CUSTOM SPEECH MODEL WITH GUID: $line
               fi
             done <"$file" | head -$number_of_models_to_delete
           fi
@@ -377,7 +413,11 @@ jobs:
         run: |
           speech endpoint create -n endpoint_${{ env.CURRENT_COMMIT_HASH }} -l ${{ env.SPEECH_LOCALE }} -m ${{ env.CUSTOM_SPEECH_MODEL_ID }} -lm ${{ env.CUSTOM_SPEECH_MODEL_ID }} --wait > ${{ env.TRAIN_BUILD_FOLDER_PATH }}/endpoint-output.txt
           endpoint_id=$(cat ${{ env.TRAIN_BUILD_FOLDER_PATH }}/endpoint-output.txt | sed -n '3p')
-          if ! [[ ${endpoint_id//-/} =~ ^[[:xdigit:]]{32}$ ]]; then exit 1; fi
+          if ! [[ ${endpoint_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
+          then
+            echo "::error ::Failed to create an endpoint. Possibly re-run all jobs."
+            exit 1
+          fi
           echo '{"ENDPOINT_ID":"'$endpoint_id'"}' > ${{ env.TRAIN_BUILD_FOLDER_PATH }}/${{ env.RELEASE_FILE }}
 
       - name: Create Release


### PR DESCRIPTION
Tested in this [run](https://github.com/KatieProchilo/Speech-Service-DevOps-Samples/actions/runs/99555003) 

It's necessary to have both the error message and the exit 1 since the workflow won't fail without the exit 1. However, with the [syntax](https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message) `echo "::error file=app.js,line=10,col=15::Something went wrong"` it presents the error to the user at the workflow level:

![image](https://user-images.githubusercontent.com/43346846/81456201-5a7b7500-9146-11ea-9ff8-da081ffb5668.png)

The error messaging is meant to help users quickly resolve any issues the pipeline might run into without needing to click into job logging. Any echoing for successes is for user debugging as well, but they'll need to click into the job to view that.