### PR TITLE
Account for Acoustic vs. Language model.

### DIFF
--- a/.github/workflows/speech-test-data-ci.yml
+++ b/.github/workflows/speech-test-data-ci.yml
@@ -114,10 +114,22 @@ jobs:
           fi
           echo "::set-env name=AUDIO_TRANS_TEST_ID::$(echo $audio_trans_test_id)"
 
-      # Get the benchmark Speech model. Fail if a GUID is not generated.
+      # Get the benchmark Speech model. Fail if a GUID is not generated. Custom
+      # Speech models trained with the V2 SDK must be trained with either a
+      # language model or acoustic model. `custom_speech_model_kind` will be
+      # used to filter results from the `speech model list` command to get the
+      # benchmark Speech model. From similar checks in the `setup` job, we know
+      # the repository is properly configured and only have to do minimal
+      # checking here.
       - name: Get the benchmark Speech model
         run: |
+          custom_speech_model_kind="Acoustic"
+          if [[ -z "${{ env.TEST_AUDIO_ZIP_FILE }}" ]]
+          then
+            custom_speech_model_kind="Language"
+          fi
           speech model list > ${{ env.TEST_BUILD_FOLDER_PATH }}/speech-model-list.txt
+          sed -i "/$custom_speech_model_kind/!d" ${{ env.TEST_BUILD_FOLDER_PATH }}/speech-model-list.txt
           custom_speech_model_id=$(cat ${{ env.TEST_BUILD_FOLDER_PATH }}/speech-model-list.txt | tail -1 | awk '{print $1;}')
           if ! [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
           then

--- a/.github/workflows/speech-train-data-ci-cd.yml
+++ b/.github/workflows/speech-train-data-ci-cd.yml
@@ -31,8 +31,8 @@ env:
   #############################################################################
   PRONUNCIATION_FILE_PATH: "training/pronunciation.txt"
   RELATED_TEXT_FILE_PATH: "training/related-text.txt"
-  TRAIN_TRANS_FILE: "trans.txt"
-  TRAIN_ZIP_SOURCE_PATH: "training/audio-and-trans.zip"
+  TRAIN_TRANS_FILE: ""
+  TRAIN_ZIP_SOURCE_PATH: ""
 
 jobs:
   #############################################################################
@@ -104,6 +104,34 @@ jobs:
           echo "::set-env name=TRAIN_AUDIO_ZIP_FILE::train-audio.zip"
           echo "::set-env name=TRAIN_BUILD_FOLDER_PATH::build-speech-train"
 
+      # Custom Speech models trained with the V2 SDK must have either
+      # TRAIN_ZIP_SOURCE_PATH or both PRONUNCIATION_FILE_PATH and
+      # RELATED_TEXT_FILE_PATH so that only a language model or acoustic model
+      # will be trained.
+      - name: Prepare for an Acoustic or Language model
+        run: |
+          if [[ "${{ env.PRONUNCIATION_FILE_PATH }}" == "" ]] && [[ "${{ env.RELATED_TEXT_FILE_PATH }}" == "" ]]
+          then
+            if [[ "${{ env.TRAIN_ZIP_SOURCE_PATH }}" == "" ]]
+            then
+              echo "::error ::Define both PRONUNCIATION_FILE_PATH and RELATED_TEXT_FILE_PATH to train language models. Or define TRAIN_ZIP_SOURCE_PATH to train acoustic models."
+              exit 1
+            fi
+            echo CONFIGURED REPOSITORY FOR ACOUSTIC MODELS.
+          elif [[ "${{ env.TRAIN_ZIP_SOURCE_PATH }}" == "" ]]
+          then
+            if [[ "${{ env.PRONUNCIATION_FILE_PATH }}" == "" ]] || [[ "${{ env.RELATED_TEXT_FILE_PATH }}" == "" ]]
+            then
+              echo "::error ::If TRAIN_ZIP_SOURCE_PATH is not defined, then PRONUNCIATION_FILE_PATH and RELATED_TEXT_FILE_PATH must both be defined to train language models."
+              exit 1
+            fi
+            mkdir "${{ env.TRAIN_BUILD_FOLDER_PATH }}"
+            echo CONFIGURED REPOSITORY FOR LANGUAGE MODELS.
+          else
+            echo "::error ::Define both PRONUNCIATION_FILE_PATH and RELATED_TEXT_FILE_PATH to train language models. Or define TRAIN_ZIP_SOURCE_PATH to train acoustic models."
+            exit 1
+          fi
+
       # https://github.com/msimecek/Azure-Speech-CLI
       - name: Install and configure Azure Speech CLI
         run: |
@@ -147,7 +175,7 @@ jobs:
             exit 1
           fi
           echo "::set-env name=PRONUNCIATION_ID::$(echo $pronunciation_id)"
-          echo "::set-env name=CUSTOM_SPEECH_MODEL_DATA::${{ env.CUSTOM_SPEECH_MODEL_DATA }} -pro $pronunciation_id"
+          echo "::set-env name=CUSTOM_SPEECH_MODEL_DATA::-pro $pronunciation_id"
 
       # Upload language data to Speech. Fail if a GUID is not generated.
       - name: Upload language data
@@ -376,10 +404,22 @@ jobs:
           dotnet tool install -g azurespeechcli --version 1.5.2
           speech config set -n ${{ secrets.SPEECH_PROJECT_NAME }} -k ${{ secrets.SPEECH_SUBSCRIPTION_KEY }} -r ${{ secrets.SPEECH_RESOURCE_REGION }} -s
 
+      # Custom Speech models trained with the V2 SDK must be trained with either
+      # a language model or acoustic model. `custom_speech_model_kind` will be
+      # used to filter results from the `speech model list` command to get the
+      # benchmark Speech model. From similar checks in the `setup` job, we know
+      # the repository is properly configured and only have to do minimal
+      # checking here.
       - name: Get the benchmark Speech model
         run: |
+          custom_speech_model_kind="Acoustic"
+          if [[ -z "${{ env.TRAIN_ZIP_SOURCE_PATH }}" ]]
+          then
+            custom_speech_model_kind="Language"
+          fi
           mkdir ${{ env.TRAIN_BUILD_FOLDER_PATH }}
           speech model list > ${{ env.TRAIN_BUILD_FOLDER_PATH }}/speech-model-list.txt
+          sed -i "/$custom_speech_model_kind/!d" ${{ env.TRAIN_BUILD_FOLDER_PATH }}/speech-model-list.txt
           custom_speech_model_id=$(cat ${{ env.TRAIN_BUILD_FOLDER_PATH }}/speech-model-list.txt | tail -1 | awk '{print $1;}')
           if ! [[ ${custom_speech_model_id//-/} =~ ^[[:xdigit:]]{32}$ ]]
           then


### PR DESCRIPTION
This PR solves a couple of bugs. First, things didn't work as expected when we tried to add acoustic and language data at the same time. Second, endpoints were built with the oldest language model - never acoustic models, and never the benchmark model.

The step `Prepare for an Acoustic or Language model` validates that the proper data files are excluded so that if they're building an acoustic model, only the audio+human-labeled transcript file path is included. If they're building a language model, they'll need pronunciation and language data defined.
* [Works properly for language models](https://github.com/KatieProchilo/Speech-Service-DevOps-Samples/runs/676733169)
* [Works properly for acoustic models](https://github.com/KatieProchilo/Speech-Service-DevOps-Samples/runs/676739453)
* [Works properly for when no data is defined](https://github.com/KatieProchilo/Speech-Service-DevOps-Samples/actions/runs/105276814)
* [Works properly for when all data is defined](https://github.com/KatieProchilo/Speech-Service-DevOps-Samples/actions/runs/105276922)

We do a similar but simplified comparison in the release job to get the model kind - it can be either Acoustic or Language. We use this model kind to filter models from the `speech model list` command, which will leave us with a list of only the correct model kind. Now we can just pluck the latest correct kind of model from that list (which will be the newly created model), and we've solved the bug.
* [Works properly to get the latest Custom Speech model](https://github.com/KatieProchilo/Speech-Service-DevOps-Samples/runs/677017294)