### PR TITLE
Delete duplicate mkdir.

### DIFF
--- a/.github/workflows/speech-train-data-ci-cd.yml
+++ b/.github/workflows/speech-train-data-ci-cd.yml
@@ -159,10 +159,6 @@ jobs:
           echo "::set-env name=AUDIO_TRANS_TRAIN_ID::$(echo $audio_trans_train_id)"
           echo "::set-env name=CUSTOM_SPEECH_MODEL_DATA::--audio-dataset $audio_trans_train_id"
 
-      - name: Create the build directory
-        if: env.TRAIN_ZIP_SOURCE_PATH == ''
-        run: mkdir ${{ env.TRAIN_BUILD_FOLDER_PATH }}
-
       # Upload pronunciation data to Speech. Fail if a GUID is not generated.
       - name: Upload pronunciation data
         if: env.PRONUNCIATION_FILE_PATH && env.PRONUNCIATION_FILE_PATH != ''


### PR DESCRIPTION
`env.TRAIN_BUILD_FOLDER_PATH` only needs to be created once per job. @Joll59 found that we were creating this directory twice which made the run end in an error. I removed the standalone step where we create the directory because this is already handled implicitly for Acoustic data (the `unzip` command handles this) and explicitly for Language data (i.e. with another `mkdir` command in the same job)