### PR TITLE
change actions to retrieve action by commit hash instead of version tag.

### DIFF
--- a/.github/workflows/speech-train-data-ci-cd.yml
+++ b/.github/workflows/speech-train-data-ci-cd.yml
@@ -455,12 +455,12 @@ jobs:
 
       # https://github.com/GitTools/GitVersion
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.3
+        uses: gittools/actions/gitversion/setup@6dfe406
         with:
           versionSpec: "5.2.x"
       - name: Use GitVersion
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.3
+        uses: gittools/actions/gitversion/execute@6dfe406
 
       - name: Set environment variables
         run: |


### PR DESCRIPTION
actions have an inherent security flaw highlighted by this [blog post](https://julienrenaux.fr/2019/12/20/github-actions-security-risk/), a working solution is to retrieve the action via the commit hash. This poses a different type of security flaw, but one with a much higher barrier for circumvention. 

Currently only addressed for actions that are external to Microsoft and GitHub, that we've taken a dependency on. 
GitVersion via GitTools. 
installation of GitVersion retrieved via commit hash.
![image](https://user-images.githubusercontent.com/16693765/83204457-7e145880-a111-11ea-97df-d8287376f44e.png)
Including an execution of GitVersion retrieved via commit hash

![image](https://user-images.githubusercontent.com/16693765/83426077-3ed95680-a3f4-11ea-8dd0-c0cf099c5211.png)
