### PR TITLE
workflow shows warning on model deletion error

### DIFF
--- a/.github/workflows/speech-train-data-ci-cd.yml
+++ b/.github/workflows/speech-train-data-ci-cd.yml
@@ -517,7 +517,12 @@ jobs:
               if [[ ${line//-/} =~ ^[[:xdigit:]]{32}$ ]]
               then
                 speech model delete $line
-                echo DELETED CUSTOM SPEECH MODEL WITH GUID: "$line"
+                if [[ ${?} -gt 0 ]]
+                then
+                  echo "::warning::Bad deletion request detected, likely scenario a model is still attached to an endpoint"
+                else
+                  echo DELETED CUSTOM SPEECH MODEL WITH GUID: "$line"
+                fi
               fi
             done < "$speech_model_list_file" | head -$number_of_models_to_delete
           fi


### PR DESCRIPTION
There needs to be a warning message when the workflow can not delete a model due to bad requests.

Closes #50 