### PR TITLE
Rename references to primary branch

### DIFF
--- a/.github/workflows/speech-test-data-ci.yml
+++ b/.github/workflows/speech-test-data-ci.yml
@@ -11,9 +11,9 @@ name: SpeechTestDataCI
 
 on:
   push:
-    # Execute on pushes to master.
+    # Execute on pushes to main.
     branches:
-      - master
+      - main
     # The push must include updates to testing data.
     paths:
       # The path from the root of the repository to a .zip with .wav files and a

--- a/.github/workflows/speech-train-data-ci-cd.yml
+++ b/.github/workflows/speech-train-data-ci-cd.yml
@@ -11,9 +11,9 @@ name: SpeechTrainDataCICD
 
 on:
   push:
-    # Execute on pushes to master.
+    # Execute on pushes to main.
     branches:
-      - master
+      - main
     # The push must include updates to training data.
     paths:
       # The path from the root of the repository to a .zip with .wav files and a

--- a/documentation/1-setup.md
+++ b/documentation/1-setup.md
@@ -9,7 +9,7 @@ This document shows how to create your GitHub repository from this template, cre
 - [Create the Speech project](#Create-the-Speech-project)
 - [Create GitHub secrets](#Create-GitHub-secrets)
 - [Create the Azure Service Principal](#Create-the-Azure-Service-Principal)
-- [Protect the master branch](#Protect-the-master-branch)
+- [Protect the main branch](#Protect-the-main-branch)
 - [Next steps](#Next-steps)
 
 ## Create your repo
@@ -28,7 +28,7 @@ To create your repository:
 
         >**Note**: The template works with public repositories by default. If you create a private repository, you will need to [configure the workflows](4-advanced-customization.md##Change-Environment-Variables) for use with a  private repository.
 
-    1. Leave **Include all branches** unchecked as you only need the master branch.
+    1. Leave **Include all branches** unchecked as you only need the main branch.
     1. Click **Create repository from template** to create your copy of this repository.
 
 1. After your repository is created, [clone the repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository).
@@ -153,13 +153,13 @@ To create the Azure Service Principal:
 
     ![GitHub secrets](../images/GitHubSecrets.png)
 
-## Protect the master branch
+## Protect the main branch
 
-It's a software engineering best practice to protect the master branch from direct check-ins. Read [configuring protected branches](https://help.github.com/en/github/administering-a-repository/configuring-protected-branches) to learn more about protecting branches in GitHub.
+It's a software engineering best practice to protect the main branch from direct check-ins. Read [configuring protected branches](https://help.github.com/en/github/administering-a-repository/configuring-protected-branches) to learn more about protecting branches in GitHub.
 
 > **Important:** Branch protections are supported on public GitHub repositories, or if you have a GitHub Pro subscription. If you are using a personal GitHub account and you created your repository as a private repository, you will have to change your repository to be **public**.
 
-The GitHub Actions workflows in this repository are configured to run when a merge to master occurs, for example after a PR is merged.
+The GitHub Actions workflows in this repository are configured to run when a merge to main occurs, for example after a PR is merged.
 Branch Protections are not required for these events to occur, so setting branch protections is optional.
 
 Configure branch protections according to your established software engineering process. If you don't have established branch protection policies, configure branch protections as follows:
@@ -168,7 +168,7 @@ Configure branch protections according to your established software engineering 
 1. Select **Branches** in the left menu.
 1. Under **Branch protection rules**, click **Add rule**.
 1. Enter the following for the rule:
-    1. In the **Branch name pattern** box, enter **master**.
+    1. In the **Branch name pattern** box, enter **main**.
     1. Check **Require pull request reviews before merging**.
     1. Do **not** check **Include administrators**.
         - You will use your administrator privileges to bypass merge restrictions later in this walk through.

--- a/documentation/2-test-the-baseline-model.md
+++ b/documentation/2-test-the-baseline-model.md
@@ -15,7 +15,7 @@ Push a tag beginning with `BASELINE` to trigger a GitHub Actions workflow that t
 1. To push a tag, enter the following in a command window in the root folder of your repo:
 
     ```bash
-    git checkout master
+    git checkout main
     git pull
     git tag BASELINE_0
     git push origin BASELINE_0
@@ -25,7 +25,7 @@ Push a tag beginning with `BASELINE` to trigger a GitHub Actions workflow that t
 
 ## Confirm the workflow results
 
-When you push a baseline tag to **master**, the **SpeechTestDataCI** workflow found at `.github/workflows/speech-test-data-ci.yml` tests the baseline model against the test data and outputs test results and a test summary. Since this is the first time these tests have been run, the results become the benchmark that future models must outperform.
+When you push a baseline tag to **main**, the **SpeechTestDataCI** workflow found at `.github/workflows/speech-test-data-ci.yml` tests the baseline model against the test data and outputs test results and a test summary. Since this is the first time these tests have been run, the results become the benchmark that future models must outperform.
 
 ### View the workflow run
 

--- a/documentation/3-improve-the-model.md
+++ b/documentation/3-improve-the-model.md
@@ -40,10 +40,10 @@ Create a feature branch for your updates to the training and testing data.
 
 To create a feature branch:
 
-1. Navigate to the root of the repository and create a feature branch from master:
+1. Navigate to the root of the repository and create a feature branch from main:
 
     ```bash
-    git checkout master
+    git checkout main
     git pull
     git checkout -b newSpeechModel
     ```
@@ -115,7 +115,7 @@ If the WER did not improve, add more training data and test the effect on the mo
 
 ## Create the pull request
 
-Once you are satisfied with how your development model performs based on your changes, create a pull request to submit those changes to **master**.
+Once you are satisfied with how your development model performs based on your changes, create a pull request to submit those changes to **main**.
 
 To create the pull request:
 
@@ -125,13 +125,13 @@ To create the pull request:
     git push -u origin newSpeechModel
     ```
 
-1. Create a pull request from **newSpeechModel** to **master**.
-1. Click the **Merge pull request** button to merge the pull request into **master**.
+1. Create a pull request from **newSpeechModel** to **main**.
+1. Click the **Merge pull request** button to merge the pull request into **main**.
     >**Note:** If you have set up branch protection policies, you will need to check **Use your administrator privileges** to merge the pull request.
 
 ## Confirm the workflows
 
-In this walkthrough, you merged a pull request to **master** with updates to both the testing and training data. GitHub Action workflows stored in the `.github/workflows/` directory will run when triggered. Updates to testing data trigger the **SpeechTestDataCI** workflow, while updates to training data trigger the **SpeechTrainDataCICD** workflow. Immediately after merging your pull request, click on the **Actions** tab on GitHub to see both of them running.
+In this walkthrough, you merged a pull request to **main** with updates to both the testing and training data. GitHub Action workflows stored in the `.github/workflows/` directory will run when triggered. Updates to testing data trigger the **SpeechTestDataCI** workflow, while updates to training data trigger the **SpeechTrainDataCICD** workflow. Immediately after merging your pull request, click on the **Actions** tab on GitHub to see both of them running.
 
 ### Confirm the testing workflow results
 

--- a/documentation/4-advanced-customization.md
+++ b/documentation/4-advanced-customization.md
@@ -6,7 +6,7 @@ Tailor your repository to your needs using these advanced customizations.
 
 * [Change environment variables](#Change-environment-variables)
 * [Change locales](#Change-locales)
-* [Configure a clean master](#Configure-a-clean-master)
+* [Configure a clean main](#Configure-a-clean-main)
 * [Exclude training data](#Exclude-training-data)
 * [Use Git Large File Storage](#Use-Git-Large-File-Storage)
 
@@ -45,25 +45,25 @@ Change `en-US` to the locale that works best for your project, but note its avai
 
 If under **Customizations** it says "No" for your locale, that means Custom Speech is not supported and you must exclude all three types of training data. You can still use this solution to test the baseline Azure Speech models against test data and/or as new baseline models are released.
 
-## Configure a clean master
+## Configure a clean main
 
-The training data in **master** does not always represent an improved Custom Speech model because the workflows execute *after* a pull request has already been merged, meaning there is no way to guarantee that model has improved with each change. This doesn't present a problem considering the behavior when models improve - a Custom Speech endpoint is created, a GitHub release is created containing that endpoint, and the repository is tagged with a new version. This approach is preferred because training Custom Speech models and testing them against a large data set will take a long time, and is only done once for each commit to master.
+The training data in **main** does not always represent an improved Custom Speech model because the workflows execute *after* a pull request has already been merged, meaning there is no way to guarantee that model has improved with each change. This doesn't present a problem considering the behavior when models improve - a Custom Speech endpoint is created, a GitHub release is created containing that endpoint, and the repository is tagged with a new version. This approach is preferred because training Custom Speech models and testing them against a large data set will take a long time, and is only done once for each commit to main.
 
-An alternative branching strategy can ensure a "clean" **master** where every commit represents an improved Custom Speech model. Many branching strategies will solve this problem, but [Gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) is simple and will show the general changes necessary for any branch strategy. With Gitflow, merge feature branches into **develop** and merge **develop** into **master** so that every commit in **master** represents an improved Custom Speech model.
+An alternative branching strategy can ensure a "clean" **main** where every commit represents an improved Custom Speech model. Many branching strategies will solve this problem, but [Gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) is simple and will show the general changes necessary for any branch strategy. With Gitflow, merge feature branches into **develop** and merge **develop** into **main** so that every commit in **main** represents an improved Custom Speech model.
 
 ### Edit branches
 
-Complete the following to configure a clean **master**:
+Complete the following to configure a clean **main**:
 
-1. Configure [Gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) by creating a **develop** branch from master.
+1. Configure [Gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) by creating a **develop** branch from main.
 1. Find the following YAML in both `.github/workflows/speech-test-data-ci.yml` and `.github/workflows/speech-train-data-ci-cd.yml`:
 
     ```yml
     on:
       push:
-        # Execute on pushes to master.
+        # Execute on pushes to main.
         branches:
-          - master
+          - main
     ```
 
 1. Add the **develop** branch to `branches`:
@@ -71,19 +71,19 @@ Complete the following to configure a clean **master**:
     ```yml
     on:
       push:
-        # Execute on pushes to master and develop.
+        # Execute on pushes to main and develop.
         branches:
-          - master
+          - main
           - develop
     ```
 
-1. Add, commit, and push these changes so that both workflows trigger on pushes to **master** and **develop**. For more information, read about [GitHub events that trigger workflows](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#on).
+1. Add, commit, and push these changes so that both workflows trigger on pushes to **main** and **develop**. For more information, read about [GitHub events that trigger workflows](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#on).
 
-### Protect the master and develop branches
+### Protect the main and develop branches
 
-During Setup, you protected the **master** branch. [Follow the same steps](1-setup.md#Protect-the-master-branch) to create a rule for the **develop** branch so that pushes to that branch also require updates to be made via approved pull requests.
+During Setup, you protected the **main** branch. [Follow the same steps](1-setup.md#Protect-the-main-branch) to create a rule for the **develop** branch so that pushes to that branch also require updates to be made via approved pull requests.
 
-With the branch protections and triggers in place, create pull requests from feature branches to **develop**. If the models in **develop** improve, create pull requests from **develop** to **master** so that every commit in **master** represents an improved Custom Speech model.
+With the branch protections and triggers in place, create pull requests from feature branches to **develop**. If the models in **develop** improve, create pull requests from **develop** to **main** so that every commit in **main** represents an improved Custom Speech model.
 
 ## Exclude training data
 
@@ -174,7 +174,7 @@ There are alternatives to Git LFS for managing this data, such as [Azure Blob St
 
 Follow these steps to convert your repo to use Git LFS:
 
-1. Navigate to the root of the repository and create a feature branch from **master**:
+1. Navigate to the root of the repository and create a feature branch from **main**:
 
     ```bash
     git checkout -b gitLFS
@@ -191,7 +191,7 @@ Follow these steps to convert your repo to use Git LFS:
 1. Track the testing and training data, and add them as Git LFS objects:
 
     ```bash
-    git checkout -b gitLFS master
+    git checkout -b gitLFS main
     git lfs track "*.zip"
     git add .gitattributes
     git commit -m "Track large files with LFS."
@@ -221,7 +221,7 @@ The testing and training data is currently stored as Git objects and needs to be
     3a7ddef774 - training/audio-and-trans.zip
     ```
 
-1. Merge the changes into **master**.
+1. Merge the changes into **main**.
 1. If needed, [purchase more large file storage](https://help.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/upgrading-git-large-file-storage) through GitHub.
 
 Your repository is configured to use Git LFS to track *.zip files. How you use the repository doesn't change, but now Git LFS will only pull down those files when you need to interact with them.


### PR DESCRIPTION
Many communities, both on GitHub and in the wider Git community, are considering renaming the default branch name of their repository from master. This repo has already been updated to rename the default branch and this change re-maps references in the documentation, ci files, etc